### PR TITLE
Simplify usage with a typeclass and simpler return type.

### DIFF
--- a/Language/Elm/Yesod.hs
+++ b/Language/Elm/Yesod.hs
@@ -25,6 +25,7 @@ import Text.Julius
 import Yesod.Core (Route (..))
 import Yesod.Handler (getUrlRenderParams, GHandler (..))
 import Yesod.Widget
+import Yesod.Handler (lift)
 import Language.Elm
 import Language.Elm.Quasi
 
@@ -34,10 +35,10 @@ import qualified Data.Text.Lazy as TL
 -- |elmWidget returns a Yesod widget from some Elm source code
 --  with URL interpolation.
 elmWidget :: ElmUrl (Route master) -- ^ Elm source code
-          -> GHandler sub master (GWidget sub master())
+          -> GWidget sub master()
 elmWidget source = do
-  urlF <- getUrlRenderParams
-  return $ mkElmWidget source urlF
+  urlF <- lift getUrlRenderParams
+  mkElmWidget source urlF
 
 
 mkElmWidget :: ElmUrl (Route master)   -- ^ Elm source code

--- a/Language/Elm/Yesod.hs
+++ b/Language/Elm/Yesod.hs
@@ -7,11 +7,9 @@
 
    > instance Yesod App where
    >    jsLoader _ = BottomOfHeadBlocking -- moves JS to the <head> tag
-   >    defaultLayout widget = do
-   >        pc <- widgetToPageContent $ do
-   >            addScriptRemote $ "http://somecdn.org/link/to/elm-min.js"
-   >            ...
-   >        ...
+
+     You also need to define an instance of 'YesodElm', which will specify
+     where to find the elm-min.js file.
 
      A full example implementation is provided in the examples folder of the Elm github repository.
 -}
@@ -34,6 +32,8 @@ import qualified Data.Text as TS
 import qualified Data.Text.Lazy as TL
 
 class YesodElm master where
+    -- | The location of the elm-min.js file. This can be either a type-safe
+    -- route (@Left@) or a raw string (@Right@).
     urlElmJs :: a -> Either (Route master) TS.Text
 
 -- |elmWidget returns a Yesod widget from some Elm source code

--- a/Language/Elm/Yesod.hs
+++ b/Language/Elm/Yesod.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes, TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TypeFamilies #-}
 {- | This module provides a function for compiling Elm source code into a Yesod widget.
      In order to use this with your Yesod app, you need to define a defaultLayout like
      function that embeds the elm-min.js file /in the <head> tag/.
@@ -35,6 +36,10 @@ class YesodElm master where
     -- | The location of the elm-min.js file. This can be either a type-safe
     -- route (@Left@) or a raw string (@Right@).
     urlElmJs :: a -> Either (Route master) TS.Text
+
+instance (YesodElm master, render ~ RenderFn (Route master))
+  => ToWidget sub master (render -> Elm) where
+    toWidget = elmWidget
 
 -- |elmWidget returns a Yesod widget from some Elm source code
 --  with URL interpolation.

--- a/Language/Elm/Yesod.hs
+++ b/Language/Elm/Yesod.hs
@@ -17,6 +17,7 @@
 -}
 module Language.Elm.Yesod (
         elmWidget
+      , YesodElm (..)
       , ElmUrl) where
 
 import Control.Monad (liftM)
@@ -25,20 +26,26 @@ import Text.Julius
 import Yesod.Core (Route (..))
 import Yesod.Handler (getUrlRenderParams, GHandler (..))
 import Yesod.Widget
-import Yesod.Handler (lift)
+import Yesod.Handler (lift, getYesod)
 import Language.Elm
 import Language.Elm.Quasi
 
 import qualified Data.Text as TS
 import qualified Data.Text.Lazy as TL
 
+class YesodElm master where
+    urlElmJs :: a -> Either (Route master) TS.Text
+
 -- |elmWidget returns a Yesod widget from some Elm source code
 --  with URL interpolation.
-elmWidget :: ElmUrl (Route master) -- ^ Elm source code
+elmWidget :: YesodElm master
+          => ElmUrl (Route master) -- ^ Elm source code
           -> GWidget sub master()
 elmWidget source = do
   urlF <- lift getUrlRenderParams
   mkElmWidget source urlF
+  master <- lift getYesod
+  addScriptEither $ urlElmJs master
 
 
 mkElmWidget :: ElmUrl (Route master)   -- ^ Elm source code


### PR DESCRIPTION
The addition of the `YesodElm` typeclass statically ensures that the necessary JS file is included in the page. Ideally, I'd like to also modify this so that the `BottomOfHeadBlocking` change isn't necessary, but this probably requires upstream changes in Elm itself (I at least couldn't get it working after working a few minutes on it).

Also, flattening the return type from `Handler Widget` to `Widget` makes it possible to write code such as:

```
getClockR :: Handler RepHtml
getClockR = do 
    defaultLayout $ do
      setTitle "A clock"
      toWidget $(elmFile "elm_source/clock.elm")
```
