### PR TITLE
Fix issues #2 and #3 (making elm-yesod compile against yesod 1.1.7.1)

### DIFF
--- a/Language/Elm/Yesod.hs
+++ b/Language/Elm/Yesod.hs
@@ -65,7 +65,7 @@ mkElmWidget source urlFn jsl =
   let (html, css, js) = toParts (urlFn, source)
       initscript = [julius| Dispatcher.initialize(); |]
   in do toWidgetHead css
-        toWidget [julius| #{js} |]
+        toWidget [julius| #{rawJS js} |]
         toWidget html
         case jsl of
           BottomOfBody -> toWidget initscript  -- insert as last script


### PR DESCRIPTION
Fix elm-yesod to compile against yesod 1.1.7.1 (shakespeare 1.1.1).
Broken by "Disable legacy ToJavascript instances" change to julius 1.0.2 -> 1.1.0
See:
https://github.com/yesodweb/shakespeare/commit/d5a1b570198d79becee71f5a06fe3e45fba8a902#shakespeare-js/Text/Julius.hs

Fixes issues #2 and #3 
