### PR TITLE
Fixes issue#5 (elm-yesod example index.elm broken)

### DIFF
--- a/Language/Elm/Yesod.hs
+++ b/Language/Elm/Yesod.hs
@@ -65,7 +65,7 @@ mkElmWidget source urlFn jsl =
   let (html, css, js) = toParts (urlFn, source)
       initscript = [julius| Dispatcher.initialize(); |]
   in do toWidgetHead css
-        toWidget [julius| #{rawJS js} |]
+        toWidgetBody [julius| #{rawJS js} |]  -- insert in body so elm can find document.body  (see issue#5)
         toWidget html
         case jsl of
           BottomOfBody -> toWidget initscript  -- insert as last script


### PR DESCRIPTION
Fixes issue#5 https://github.com/tazjin/elm-yesod/issues/5
Previous code placed compiled javascript in element "head".
Needs to be put in the element "body" otherwise document editing doesn't work.

Tested ghc-7.4.1, elm-yesod-0.1.3, Elm-0.7.1.1, yesod-1.1.7.1
